### PR TITLE
Unify electrum to crafts and additions electrum when the mod is insta…

### DIFF
--- a/overrides/kubejs/client_scripts/bulkhide.js
+++ b/overrides/kubejs/client_scripts/bulkhide.js
@@ -351,6 +351,12 @@ onEvent('rei.hide.items', event => {
 	event.hide('kubejs:gold_coin')
 	event.hide('thermal:servo_attachment')
 
+	if (Platform.isLoaded("createaddition")) {
+		event.hide("thermal:electrum_ingot");
+		event.hide("thermal:electrum_nugget");
+		event.hide("thermal:electrum_plate");
+		event.hide("createaddition:zinc_sheet");
+	}
 	if (!Platform.isLoaded("malum")) {
 		event.hide("#buddycardsexp:buddycards_malum")
 	}

--- a/overrides/kubejs/server_scripts/compatibility.js
+++ b/overrides/kubejs/server_scripts/compatibility.js
@@ -42,14 +42,19 @@ onEvent('recipes', event => {
 		machine('brass','createaddition:tesla_coil', 1, 'createaddition:copper_spool')
 		machine('brass','createaddition:modular_accumulator', 1, 'thermal:energy_cell_frame')
 
+		event.replaceOutput({}, '#forge:nuggets/electrum','createaddition:electrum_nugget')
+		event.replaceOutput({}, '#forge:ingots/electrum','createaddition:electrum_ingot')
+		event.replaceOutput({}, '#forge:plates/electrum','createaddition:electrum_sheet')
+
+		event.replaceOutput({id: 'kubejs:machines/smelter/electrum_ingot'}, 'thermal:electrum_ingot','createaddition:electrum_ingot')
+
 		// Duplicate Items
-		event.remove({ output: 'createaddition:electrum_ingot'})
-		event.remove({ output: 'createaddition:electrum_nugget'})
+		//event.remove({ id: 'createaddition:electrum_ingot'})
+		event.remove({ id: 'createaddition:crafting/electrum_nugget'})
 		event.remove({ output: 'createaddition:zinc_sheet'})
 
 		// Bugged Recipe
-		event.remove({ output: 'createaddition:electrum_sheet', input: 'thermal:constantan_ingot'})
-		event.recipes.createPressing('createaddition:electrum_sheet', '#forge:ingots/electrum')
+		event.replaceInput( { id:'createaddition:pressing/electrum_ingot'}, 'thermal:constantan_ingot', '#forge:ingots/electrum')
 
 		// Motor & Alternator
 		// event.remove({ output: 'createaddition:electric_motor'})

--- a/overrides/kubejs/server_scripts/recipes.js
+++ b/overrides/kubejs/server_scripts/recipes.js
@@ -389,10 +389,8 @@ function unwantedRecipes(event) {
 	event.remove({ id: TE('machines/pulverizer/pulverizer_cinnabar') })
 	event.remove({ id: TE('machines/smelter/smelter_alloy_signalum') })
 	event.remove({ id: TE('machines/smelter/smelter_alloy_lumium') })
-	event.remove({ id: TE('machines/smelter/smelter_alloy_electrum') })
 	event.remove({ id: TE('machines/smelter/smelter_alloy_enderium') })
 	event.remove({ id: TE('machines/smelter/smelter_alloy_invar') })
-	event.remove({ id: TE('machines/smelter/smelter_alloy_constantan') })
 	event.remove({ id: TE('machines/smelter/smelter_alloy_bronze') })
 	event.remove({ id: TE('compat/create/smelter_create_alloy_brass') })
 	event.remove({ id: TE('compat/tconstruct/smelter_alloy_tconstruct_rose_gold_ingot') })
@@ -1225,7 +1223,12 @@ function unify(event) {
 	event.replaceInput({ id: TE('augments/rf_coil_xfer_augment') }, F('#ingots/silver'), MC('iron_ingot'))
 	event.replaceInput({ id: TE('augments/rf_coil_augment') }, F('#ingots/silver'), MC('iron_ingot'))
 	event.replaceInput({ id: TE('tools/detonator') }, F('#ingots/silver'), TE('lead_ingot'))
-	event.replaceInput({ id: TE("machines/smelter/smelter_alloy_netherite")}, TE("gold_dust"), MC("gold_ingot"))
+
+	event.replaceInput({ id: TE("machines/smelter/smelter_alloy_constantan")}, F('#dusts/copper'), MC("copper_ingot"))
+	event.replaceInput({ id: TE("machines/smelter/smelter_alloy_constantan")}, F('#dusts/nickel'), TE("nickel_ingot"))
+	event.replaceInput({ id: TE("machines/smelter/smelter_alloy_electrum")}, F('#dusts/gold'), MC("gold_ingot"))
+	event.replaceInput({ id: TE("machines/smelter/smelter_alloy_electrum")}, F('#dusts/silver'), TE("silver_ingot"))
+	event.replaceInput({ id: TE("machines/smelter/smelter_alloy_netherite")}, F('#dusts/gold'), MC("gold_ingot"))
 
 	event.replaceOutput({ type: OC("crushing") }, OC('copper_dust'), TE('copper_dust'))
 	event.replaceOutput({ type: OC("crushing") }, OC('iron_dust'), TE('iron_dust'))
@@ -1286,6 +1289,7 @@ function unify(event) {
 	event.replaceInput({ id: TE('parts/electrum_gear') }, TE('constantan_ingot'), '#forge:ingots/electrum')
 
 	event.replaceInput({ id: TE('storage/electrum_nugget_from_ingot') }, TE('constantan_ingot'), '#forge:ingots/electrum')
+	event.replaceInput({ id: TE('storage/electrum_block') }, TE('constantan_ingot'), '#forge:ingots/electrum')
 
 	event.remove( {id: TE('storage/silver_block')})
 	event.remove( {id: TE('storage/silver_ingot_from_block')})
@@ -1639,8 +1643,6 @@ function alloys(event) {
 	event.recipes.thermal.smelter([KJ("invar_compound"), KJ("invar_compound")], [TE("nickel_ingot"), MC("iron_ingot")])
 	event.recipes.thermal.smelter(CR("brass_ingot", 2), [MC("copper_ingot"), CR("zinc_ingot")])
 	event.recipes.thermal.smelter(TC("rose_gold_ingot", 2), [MC("copper_ingot"), MC("gold_ingot")])
-	event.recipes.thermal.smelter(TE("constantan_ingot", 2), [MC("copper_ingot"), TE("nickel_ingot")])
-	event.recipes.thermal.smelter(TE("electrum_ingot", 2), [TE("silver_ingot"), MC("gold_ingot")])
 	event.recipes.thermal.smelter("3x alloyed:bronze_ingot", [MC("copper_ingot", 3), '#forge:sand'])
 
 }


### PR DESCRIPTION
Unify electrum to crafts and additions electrum when the mod is installed and fix electrum block bug

-Unify electrum recipes to crafts and additions when it is installed
-hide thermal electrum electrum ingot, nugget and plate when C&A is installed
-hide C&A zinc sheet (duplicate item)
-fix electrum block crafting bug
-fix thermal induction smelter recipes so they can be modified by kubejs compatability scripts